### PR TITLE
Fix "Unspecified pixel format" issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,19 +3,21 @@
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
-  "configurations": [{
-    "name": "Debug",
-    "type": "cppdbg",
-    "request": "launch",
-    "program": "${workspaceFolder}/out/testFFMpeg",
-    "args": [
-      "${workspaceFolder}/IMG_0010.MOV"
-    ],
-    "stopAtEntry": false,
-    "cwd": "${workspaceFolder}",
-    "environment": [],
-    "externalConsole": false,
-    "MIMode": "lldb",
-    "preLaunchTask": "Build"
-  }]
+  "configurations": [
+    {
+      "name": "Debug",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/out/testFFMpeg",
+      "args": [
+        "${workspaceFolder}/movie.mp4"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "lldb",
+      "preLaunchTask": "Build"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.associations": {
+    "*.yaml": "yaml",
     "avcodec.h": "c",
     "ios": "c",
     "stdint.h": "c",
@@ -50,7 +51,9 @@
     "typeinfo": "cpp",
     "unordered_map": "cpp",
     "stddef.h": "c",
-    "codec.h": "c"
+    "codec.h": "c",
+    "frame_grabber.h": "c",
+    "avformat.h": "c"
   },
   "C_Cpp.errorSquiggles": "Enabled",
   "C_Cpp.default.macFrameworkPath": [

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
   }
   fprintf(stdout, "Slurped file %s\n", src_filename);
 
+  av_log_set_level(AV_LOG_DEBUG);
   ResponseStatus res = grab_frame_from_byte_buffer(buffer, buffer_size, &jpeg_data, &jpeg_size, &rotate);
   printf("ResponseStatus code is %d\n", res.code);
   printf("ResponseStatus additional info: %s\n", res.description);


### PR DESCRIPTION
For some movie files, it is required to provide `seek` function pointer to `AVIOContext` to ensure successful resolution of stream information